### PR TITLE
[백준] 1024. 수열의 합 문제풀이

### DIFF
--- a/cmc/1024.py
+++ b/cmc/1024.py
@@ -1,0 +1,9 @@
+N, L = map(int, input().split())
+
+for l in range(L, 101):
+    if ((a1:=N/l-(l-1)/2) >= 0) and int(a1)==a1:
+        a1 = int(a1)
+        print(*range(a1, a1 + l), sep=' ')
+        break
+else:
+    print(-1)


### PR DESCRIPTION
등차수열의 합공식을 떠올려야 풀 수 있는 문제

등차수열의 합이 기억이 안나 다시 찾아봤습니다

Sn​=2n​(2a1​+(n−1)d)

문제에서 합은 N, 길이 L이상이라고 했으므로 Sn=N, n=L, d=1 대입하고 정리하면

N=2L(2a1+(L-1))

a1=N//L - (L-1)//2

입니다

a1이 문제 조건인 0 이상 인지, 정수 인지 체크하면 끝 입니다

시간복잡도 O(N)