### PR TITLE
[Python] BOJ1238 파티 문제풀이

### DIFF
--- a/ggg/python_solved/BOJ/BOJ1238.py
+++ b/ggg/python_solved/BOJ/BOJ1238.py
@@ -24,7 +24,6 @@ def dijkstra(start, end):
 
 ans = 0
 for i in range(1, N+1):
-    if X == i: continue
     ans = max(ans, dijkstra(i,X) + dijkstra(X,i))
 
 print(ans)


### PR DESCRIPTION
priority queue 기반으로 다익스트라 알고리즘을 사용하여 풀이하였습니다
오랜만에 찾아보려니 어렵네요

시간복잡도
`다익스트라(heap) * 반복N회 = Mlog(N) * N = NMlog(N)`