### PR TITLE
[Python] BOJ1167 트리의 지름 문제풀이

### DIFF
--- a/ggg/python_solved/BOJ/BOJ1167.py
+++ b/ggg/python_solved/BOJ/BOJ1167.py
@@ -13,17 +13,12 @@ for _ in range(V):
     for i in range(1, len(arr), 2):
         graph[arr[0]].append((arr[i], arr[i+1]))
 
-# 1. 트리의 루트는 1이라고 가정
-# 2. 루트에서 시작해서 탐색하기
 visited = [False] * (V+1)
-# 자식 노드들중에서 거리가 젤 먼걸 찾아야한다
-# 갈라지는 지점에서는 dfs로 max를 비교해야한다.
 ans = 0
-max_list = [0] * (V+1)
+
 def dfs(curr, curr_dist):
     visited[curr] = True
 
-    # 갈라지는 지점에서 현재 노드로 올 수 있는 최댓값을 탐색한다
     next_dist = [0,0]
     for next in graph[curr]:
         if not visited[next[0]]:
@@ -34,15 +29,10 @@ def dfs(curr, curr_dist):
             else:
                 next_dist[1] = max(next_dist[1], now_dist)
 
-    # 아닌 경우 - max list만 업데이트
-    max_list[curr] = next_dist[0] + curr_dist
-
-    # 갈라지는 지점이 기준이 되는 경우 - ans 업데이트
-    next_dist.sort(reverse=True)
     global ans
-    ans = max(ans, sum(next_dist), max_list[curr])
+    ans = max(ans, sum(next_dist), next_dist[0] + curr_dist)
 
     return next_dist[0] + curr_dist
 
-dfs(1,0)
+dfs(1,0) # 트리의 루트는 1이라고 가정
 print(ans)


### PR DESCRIPTION
- 트리이기 때문에 루트 노드는 아무데서나 시작해도 됨 -> 루트를 1로 가정하고 시작
- dfs(node, dist)의 정의 : 시작 node에서 리프 노드까지의 거리 합 중 최댓값

순회 방식은 아래와 같다. 이렇게 하면 한 번 순회로 해결 가능(`O(N)`)
1. 트리의 루트는 1로 가정
2. 루트에서 시작해서 리프 노드를 발견할 때 까지 dfs 재귀를 통해 탐색
3. 갈라지는 지점을 발견하면 둘 중 하나로 진행 (3-1결과와 3-2결과를 비교)
3-1. 갈라지는 지점들 중에서, 리프에 도달하는 거리의 최댓값 찾기
3-2. 현재 지점을 루트로 했을 때 거리합 구하기

자꾸 `RecursionError`가 뜨길래 첨에 무한루프 문제인가 했는데,
백준 기본값이 1000이란다 ㅡㅡ;; 
`N<=100,000`이기때문에, `sys.setrecursionlimit(10**6)`값을 따로 늘려줘야했음