### PR TITLE
[Python] BOJ1202 보석 도둑 문제풀이

### DIFF
--- a/ggg/python_solved/BOJ/BOJ1202.py
+++ b/ggg/python_solved/BOJ/BOJ1202.py
@@ -1,0 +1,28 @@
+import heapq
+import sys
+input = sys.stdin.readline
+
+N,K = map(int, input().split())
+gems, bags = [], []
+
+for _ in range(N):
+    m, v = map(int, input().split())
+    # 1순위: 가격 내림차순, 2순위: 무게 오름차순
+    heapq.heappush(gems, (m, -v))
+
+for _ in range(K):
+    bags.append(int(input()))
+bags.sort()
+
+ans = 0
+candidate = []
+idx = 0
+
+for bag in bags:
+    while gems and gems[0][0] <= bag:
+        heapq.heappush(candidate, heapq.heappop(gems)[1])
+    if candidate:
+        now = -heapq.heappop(candidate)
+        ans += now
+
+print(ans)


### PR DESCRIPTION
시간 초과의 늪에서 헤어나올 수 없었던 문제 ...

초기에는 gems 가격 순으로 정렬해서 이진탐색으로 적절한 bag을 찾으려고 했으나
적절한 bag의 사용 여부를 체크하는 과정에서 결국 O(n*k)의 시간초과가 발생해서 실패하였습니다

최종 풀이
1순위 무게 오름차순, 2순위 가격 내림차순으로 정렬 후
가방에 넣을 수 있는 보석 중 가장 가치가 높은 보석을 찾아서 넣어준다.

시간복잡도 계산
- 힙 삽입 = `log(N)`
- 가방 정렬 = `K*log(K)` (최악의 경우)
- 가방 순회 * (보석 heappop + 가방 heappush) = `K * (log(N) + log(K))`
결국 `O(K * (logN + logK))`