### PR TITLE
[boj]9084. 동전 문제풀이

### DIFF
--- a/cmc/9084.py
+++ b/cmc/9084.py
@@ -1,0 +1,14 @@
+import sys
+input = sys.stdin.readline
+
+T = int(input())
+for _ in range(T):
+    N = int(input())
+    coins = list(map(int, input().split()))
+    M = int(input())
+    dp = [0] * (M + 1)
+    dp[0] = 1
+    for coin in coins:
+        for j in range(coin, M + 1):
+            dp[j] += dp[j - coin]
+    print(dp[M])


### PR DESCRIPTION
제가 처음 생각한 코드는
```python
for i in range(M+1):
    for coin in coins:
          dp[j] += dp[j - coin]
```
이렇게 할 경우 5, 7로 12를 만들때 5+7, 7+5 인 경우가 중복으로 세져 dp[12]=2 가 되었습니다.

조합으로 경우의 수를 카운팅 할 방법을 찾지못해 커서 Composer의 도움을 받아
```python
for coin in coins:
    for j in range(coin, M + 1):
        dp[j] += dp[j - coin]
```
해당코드로 5+7 / 7+5를 두 번 세지 않는 이유
dp[12] += dp[12-7]
→ “12를 만들 때 마지막에 쓴 동전이 7인 경우”만 센다.
→ 예: 5 + 7
dp[12] += dp[12-5]
→ “마지막에 쓴 동전이 5인 경우”를 센다.
→ 예: 7 + 5
두 조합 모두 5 한 개 + 7 한 개라 실제로는 같은 경우인데,
이 DP는 동전 종류를 순서대로 하나씩 보기 때문에:
5를 먼저 보면: 5로 만들 수 있는 금액만 먼저 채움
7을 나중에 보면: 7을 한 번 사용하는 경우만 추가
따라서 “5를 먼저 쓰고 7을 쓰는 경우”와 “7을 먼저 쓰고 5를 쓰는 경우”를 따로 세지 않고, 마지막으로 추가된 동전 종류가 하나로 고정되도록 설계되어 있어서 dp[12]가 2가 아니라 1이 된다.

이해하기 어려웠지만 일단 외우려고합니다 .. 직관적으로 쉬운 이해가 있으면 공유해주시면 감사하겠습니다